### PR TITLE
Fix temporal por cambio en libreria httpx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
-httpx[http2]
+# httpx 0.28 drop the proxies param
+# TODO read https://github.com/encode/httpx/pull/3419 and update the code
+httpx[http2]==0.27.2


### PR DESCRIPTION
La libreria httpx lanzo la nueva version 0.28 que depreca el parametro `proxies` que nosotros usamos
https://github.com/encode/httpx/pull/3419

Hay que adaptar nuestro codigo siguiendo los cambios de la libreria
