### PR TITLE
Fix proxy port configuration to ensure it is an integer

### DIFF
--- a/ckanext/superset/config.py
+++ b/ckanext/superset/config.py
@@ -19,7 +19,7 @@ def get_config():
         'superset_provider': config.get("ckanext.superset.instance.provider", "db"),
         'superset_refresh': config.get("ckanext.superset.instance.refresh", "true"),
         'proxy_url': config.get("ckanext.superset.proxy.url"),
-        'proxy_port': config.get("ckanext.superset.proxy.port", '3128'),
+        'proxy_port': int(config.get("ckanext.superset.proxy.port") or 3128),
         'proxy_user': config.get("ckanext.superset.proxy.user"),
         'proxy_pass': config.get("ckanext.superset.proxy.pass"),
     }

--- a/ckanext/superset/plugin.py
+++ b/ckanext/superset/plugin.py
@@ -40,7 +40,7 @@ class SupersetPlugin(plugins.SingletonPlugin):
         declaration.declare(group.instance.provider, "db")
         declaration.declare_bool(group.instance.refresh, True)
         declaration.declare(group.proxy.url, "")
-        declaration.declare_int(group.proxy.port, 3128)
+        declaration.declare(group.proxy.port, "")
         declaration.declare(group.proxy.user, "")
         # pass is a reserved word in python, so we use with _descend
         declaration.declare(group.proxy._descend("pass"), "")


### PR DESCRIPTION
fixes  #44 

Ahora se Permite que ckanext.superset.proxy.port quede vacío cuando no se configura una URL de proxy, evitando el error "Please enter an integer value" en instancias que no utilizan proxy.